### PR TITLE
Fix segfault with conflict on morphology

### DIFF
--- a/benchmark/channels/lib/hoclib/CA1_int_bAC_011017HP2_2018011015390.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_int_bAC_011017HP2_2018011015390.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_int_bAC_011017HP2_2018011015390
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/CA1_int_cAC_010710HP2_2018011815595.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_int_cAC_010710HP2_2018011815595.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_int_cAC_010710HP2_2018011815595
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/CA1_int_cNAC_010710HP2_2018011915433.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_int_cNAC_010710HP2_2018011915433.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_int_cNAC_010710HP2_2018011915433
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_mpg141017_a1_2_idC.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_mpg141017_a1_2_idC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_pyr_cACpyr_mpg141017_a1_2_idC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_mpg141215_A_idA.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_mpg141215_A_idA.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_pyr_cACpyr_mpg141215_A_idA
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_oh140521_B0_Rat_idA.hoc
+++ b/benchmark/channels/lib/hoclib/CA1_pyr_cACpyr_oh140521_B0_Rat_idA.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate CA1_pyr_cACpyr_oh140521_B0_Rat_idA
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public channel_seed, channel_seed_set
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold

--- a/benchmark/channels/lib/hoclib/bAC_L6BTC.hoc
+++ b/benchmark/channels/lib/hoclib/bAC_L6BTC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate bAC_L6BTC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/bNAC_L23SBC.hoc
+++ b/benchmark/channels/lib/hoclib/bNAC_L23SBC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate bNAC_L23SBC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cACint_L4CHC.hoc
+++ b/benchmark/channels/lib/hoclib/cACint_L4CHC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cACint_L4CHC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L2IPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L2IPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L2IPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L2TPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L2TPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L2TPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L3TPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L3TPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L3TPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L4TPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L4TPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L4TPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L4UPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L4UPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L4UPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L5TPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L5TPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L5TPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L6BPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L6BPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L6BPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L6HPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L6HPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L6HPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L6IPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L6IPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L6IPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cADpyr_L6UPC.hoc
+++ b/benchmark/channels/lib/hoclib/cADpyr_L6UPC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cADpyr_L6UPC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/cNAC_L23BTC.hoc
+++ b/benchmark/channels/lib/hoclib/cNAC_L23BTC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate cNAC_L23BTC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]

--- a/benchmark/channels/lib/hoclib/dNAC_L23SBC.hoc
+++ b/benchmark/channels/lib/hoclib/dNAC_L23SBC.hoc
@@ -19,7 +19,7 @@ proc check_simulator() {
 }
 
 begintemplate dNAC_L23SBC
-  public init, morphology, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
+  public init, geom_nseg_fixed, geom_nsec, getCell, getCCell, setCCell, gid, getCell
   public connect2target, clear, ASCIIrpt
   public soma, dend, apic, axon, myelin, getThreshold
   create soma[1], dend[1], apic[1], axon[1], myelin[1]


### PR DESCRIPTION
The problem is that `morphology` is defined by `nrn` itself, and this `public morphology` conflicts.

The problem is visible only in nmodl because it grabs the symbol morphology later.